### PR TITLE
Fix typo in setContrastWeight parameter (contrast_weihgt → contrast_weight)

### DIFF
--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -650,7 +650,7 @@ public:
     CV_WRAP virtual void process(InputArrayOfArrays src, OutputArray dst) = 0;
 
     CV_WRAP virtual float getContrastWeight() const = 0;
-    CV_WRAP virtual void setContrastWeight(float contrast_weiht) = 0;
+    CV_WRAP virtual void setContrastWeight(float contrast_weight) = 0;
 
     CV_WRAP virtual float getSaturationWeight() const = 0;
     CV_WRAP virtual void setSaturationWeight(float saturation_weight) = 0;


### PR DESCRIPTION
Closes_issue #27474

Fixed a typo in the parameter name `contrast_weihgt`, corrected it to `contrast_weight` in photo.hpp.
 